### PR TITLE
fix:(none) -update component for IS setup

### DIFF
--- a/crd/component-sample.yaml
+++ b/crd/component-sample.yaml
@@ -6,3 +6,6 @@ metadata:
 spec:
   application: application-sample
   componentName: component-sample
+  source:
+    git:
+      url: 'https://github.com/redhat-appstudio/integration-examples'


### PR DESCRIPTION
This update is needed when seting up a IS locally.
Previous version cause to error due to missing information:


`Error from server (a git source or an image source must be specified when creating a component): error when creating "component-sample.yaml": admission webhook "vcomponent.kb.io" denied the request: a git source or an image source must be specified when creating a component`