### PR TITLE
fix(STONEINTG-667): remove build values  labels/annotations related to PaC 

### DIFF
--- a/pipelineruns/build_pipelinerun_pac_merge_pass.yaml
+++ b/pipelineruns/build_pipelinerun_pac_merge_pass.yaml
@@ -6,13 +6,13 @@ metadata:
   annotations:
     "appstudio.redhat.com/updateComponentOnSuccess": "false"
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
-    pipelinesascode.tekton.dev/repo-url: 'https://github.com/redhat-appstudio/build-service'
+    pipelinesascode.tekton.dev/repo-url:
     pipelinesascode.tekton.dev/sha-title: 'Merge pull request #35 from psturc/PLNSRVCE-281-vol2'
     pipelinesascode.tekton.dev/git-auth-secret: pac-gitauth-nthx
     pipelinesascode.tekton.dev/max-keep-runs: '5'
-    pipelinesascode.tekton.dev/sha-url: https://github.com/redhat-appstudio/build-service/commit/f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/sha-url:
     pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/installation-id: '23331085'
+    pipelinesascode.tekton.dev/installation-id: '43840620'
     chains.tekton.dev/signed: "true"
   labels:
     pipelines.appstudio.openshift.io/type: "build"
@@ -27,9 +27,9 @@ metadata:
     pipelinesascode.tekton.dev/branch: refs-heads-main
     pipelinesascode.tekton.dev/url-org: redhat-appstudio
     pipelinesascode.tekton.dev/original-prname: build-service-on-push
-    pipelinesascode.tekton.dev/url-repository: build-service
-    pipelinesascode.tekton.dev/repository: build-service-pac
-    pipelinesascode.tekton.dev/sha: f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/url-repository:
+    pipelinesascode.tekton.dev/repository:
+    pipelinesascode.tekton.dev/sha:
     pipelinesascode.tekton.dev/git-provider: github
 spec:
   pipelineRef:

--- a/pipelineruns/build_pipelinerun_pac_pr_pass.yaml
+++ b/pipelineruns/build_pipelinerun_pac_pr_pass.yaml
@@ -5,10 +5,11 @@ metadata:
   generateName: build-pipelinerun-
   annotations:
     "appstudio.redhat.com/updateComponentOnSuccess": "false"
-    pipelinesascode.tekton.dev/repo-url: 'https://github.com/redhat-appstudio/build-service'
+    pipelinesascode.tekton.dev/installation-id: '43840620'
+    pipelinesascode.tekton.dev/repo-url:
     pipelinesascode.tekton.dev/sha-title: Initial pipelines-as-code integration
-    pipelinesascode.tekton.dev/pull-request: '40'
-    pipelinesascode.tekton.dev/sha-url: https://github.com/redhat-appstudio/build-service/commit/2065ecd636e8a999cfc78ab9f1aa0d6eadbe0962
+    pipelinesascode.tekton.dev/pull-request: 
+    pipelinesascode.tekton.dev/sha-url:
     chains.tekton.dev/signed: "true"
   labels:
     pipelines.appstudio.openshift.io/type: "build"
@@ -23,9 +24,9 @@ metadata:
     pipelinesascode.tekton.dev/branch: main
     pipelinesascode.tekton.dev/url-org: redhat-appstudio
     pipelinesascode.tekton.dev/original-prname: build-service-pull-request
-    pipelinesascode.tekton.dev/url-repository: build-service
-    pipelinesascode.tekton.dev/repository: build-service-pac
-    pipelinesascode.tekton.dev/sha: 2065ecd636e8a999cfc78ab9f1aa0d6eadbe0962
+    pipelinesascode.tekton.dev/url-repository:
+    pipelinesascode.tekton.dev/repository:
+    pipelinesascode.tekton.dev/sha:
     pipelinesascode.tekton.dev/git-provider: github
 spec:
   pipelineRef:

--- a/pipelineruns/integration_pipelinerun_fail.yaml
+++ b/pipelineruns/integration_pipelinerun_fail.yaml
@@ -5,13 +5,13 @@ metadata:
   generateName: integration-pipelinerun-
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
-    pipelinesascode.tekton.dev/repo-url: 'https://github.com/redhat-appstudio/build-service'
+    pipelinesascode.tekton.dev/repo-url:
     pipelinesascode.tekton.dev/sha-title: 'Merge pull request #35 from psturc/PLNSRVCE-281-vol2'
     pipelinesascode.tekton.dev/git-auth-secret: pac-gitauth-nthx
     pipelinesascode.tekton.dev/max-keep-runs: '5'
-    pipelinesascode.tekton.dev/sha-url: https://github.com/redhat-appstudio/build-service/commit/f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/sha-url:
     pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/installation-id: '23331085'
+    pipelinesascode.tekton.dev/installation-id: '43840620'
   labels:
     pipelines.appstudio.openshift.io/type: "test"
     test.appstudio.openshift.io/test: "component"
@@ -26,9 +26,9 @@ metadata:
     pipelinesascode.tekton.dev/branch: refs-heads-main
     pipelinesascode.tekton.dev/url-org: redhat-appstudio
     pipelinesascode.tekton.dev/original-prname: build-service-on-push
-    pipelinesascode.tekton.dev/url-repository: build-service
-    pipelinesascode.tekton.dev/repository: build-service-pac
-    pipelinesascode.tekton.dev/sha: f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/url-repository:
+    pipelinesascode.tekton.dev/repository:
+    pipelinesascode.tekton.dev/sha:
     pipelinesascode.tekton.dev/git-provider: github
 spec:
   pipelineRef:

--- a/pipelineruns/integration_pipelinerun_pass.yaml
+++ b/pipelineruns/integration_pipelinerun_pass.yaml
@@ -5,13 +5,13 @@ metadata:
   generateName: integration-pipelinerun-
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
-    pipelinesascode.tekton.dev/repo-url: 'https://github.com/redhat-appstudio/build-service'
+    pipelinesascode.tekton.dev/repo-url:
     pipelinesascode.tekton.dev/sha-title: 'Merge pull request #35 from psturc/PLNSRVCE-281-vol2'
     pipelinesascode.tekton.dev/git-auth-secret: pac-gitauth-nthx
     pipelinesascode.tekton.dev/max-keep-runs: '5'
-    pipelinesascode.tekton.dev/sha-url: https://github.com/redhat-appstudio/build-service/commit/f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/sha-url:
     pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/installation-id: '23331085'
+    pipelinesascode.tekton.dev/installation-id: '43840620'
   labels:
     pipelines.appstudio.openshift.io/type: "test"
     test.appstudio.openshift.io/test: "component"
@@ -26,9 +26,9 @@ metadata:
     pipelinesascode.tekton.dev/branch: refs-heads-main
     pipelinesascode.tekton.dev/url-org: redhat-appstudio
     pipelinesascode.tekton.dev/original-prname: build-service-on-push
-    pipelinesascode.tekton.dev/url-repository: build-service
-    pipelinesascode.tekton.dev/repository: build-service-pac
-    pipelinesascode.tekton.dev/sha: f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/url-repository:
+    pipelinesascode.tekton.dev/repository:
+    pipelinesascode.tekton.dev/sha: 
     pipelinesascode.tekton.dev/git-provider: github
 spec:
   pipelineRef:

--- a/pipelineruns/integration_resolver_pipelinerun_fail.yaml
+++ b/pipelineruns/integration_resolver_pipelinerun_fail.yaml
@@ -5,13 +5,13 @@ metadata:
   generateName: integration-resolver-pipelinerun-
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
-    pipelinesascode.tekton.dev/repo-url: 'https://github.com/redhat-appstudio/build-service'
+    pipelinesascode.tekton.dev/repo-url:
     pipelinesascode.tekton.dev/sha-title: 'Merge pull request #35 from psturc/PLNSRVCE-281-vol2'
     pipelinesascode.tekton.dev/git-auth-secret: pac-gitauth-nthx
     pipelinesascode.tekton.dev/max-keep-runs: '5'
-    pipelinesascode.tekton.dev/sha-url: https://github.com/redhat-appstudio/build-service/commit/f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/sha-url:
     pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/installation-id: '23331085'
+    pipelinesascode.tekton.dev/installation-id: '43840620'
   labels:
     pipelines.appstudio.openshift.io/type: "test"
     test.appstudio.openshift.io/test: "component"
@@ -26,9 +26,9 @@ metadata:
     pipelinesascode.tekton.dev/branch: refs-heads-main
     pipelinesascode.tekton.dev/url-org: redhat-appstudio
     pipelinesascode.tekton.dev/original-prname: build-service-on-push
-    pipelinesascode.tekton.dev/url-repository: build-service
-    pipelinesascode.tekton.dev/repository: build-service-pac
-    pipelinesascode.tekton.dev/sha: f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/url-repository:
+    pipelinesascode.tekton.dev/repository:
+    pipelinesascode.tekton.dev/sha: 
     pipelinesascode.tekton.dev/git-provider: github
 spec:
   pipelineRef:

--- a/pipelineruns/integration_resolver_pipelinerun_pass.yaml
+++ b/pipelineruns/integration_resolver_pipelinerun_pass.yaml
@@ -5,13 +5,13 @@ metadata:
   generateName: integration-resolver-pipelinerun-
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
-    pipelinesascode.tekton.dev/repo-url: 'https://github.com/redhat-appstudio/build-service'
+    pipelinesascode.tekton.dev/repo-url:
     pipelinesascode.tekton.dev/sha-title: 'Merge pull request #35 from psturc/PLNSRVCE-281-vol2'
     pipelinesascode.tekton.dev/git-auth-secret: pac-gitauth-nthx
     pipelinesascode.tekton.dev/max-keep-runs: '5'
-    pipelinesascode.tekton.dev/sha-url: https://github.com/redhat-appstudio/build-service/commit/f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/sha-url:
     pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/installation-id: '23331085'
+    pipelinesascode.tekton.dev/installation-id: '43840620'
   labels:
     pipelines.appstudio.openshift.io/type: "test"
     test.appstudio.openshift.io/test: "component"
@@ -26,9 +26,9 @@ metadata:
     pipelinesascode.tekton.dev/branch: refs-heads-main
     pipelinesascode.tekton.dev/url-org: redhat-appstudio
     pipelinesascode.tekton.dev/original-prname: build-service-on-push
-    pipelinesascode.tekton.dev/url-repository: build-service
-    pipelinesascode.tekton.dev/repository: build-service-pac
-    pipelinesascode.tekton.dev/sha: f13b881e3404ad3401fa7b533df3f7daddd11b55
+    pipelinesascode.tekton.dev/url-repository:
+    pipelinesascode.tekton.dev/repository:
+    pipelinesascode.tekton.dev/sha: 
     pipelinesascode.tekton.dev/git-provider: github
 spec:
   pipelineRef:


### PR DESCRIPTION
1- In PipelineRuns examples, remove values that points to _build-service_ :
    pipelinesascode.tekton.dev/repo-url
    pipelinesascode.tekton.dev/url-repository
    pipelinesascode.tekton.dev/repository
    pipelinesascode.tekton.dev/sha-url
     
     those values should be set by user before running test, also user will have to define the webhook according to the used cluster.
     
2-  Added a consistent installation ID was created for these PipelineRuns :

   pipelinesascode.tekton.dev/installation-id: '43840620'

    
    Ticket:  [STONEINTG-667](https://issues.redhat.com/browse/STONEINTG-667)