### PR TITLE
fix(STONEINTG-892): add source to override snapshot's component

### DIFF
--- a/crd/overridesnapshot-sample.yaml
+++ b/crd/overridesnapshot-sample.yaml
@@ -10,3 +10,6 @@ spec:
   components:
     - containerImage: quay.io/redhat-user-workloads/default/application-sample/component-sample@sha256:0db0a473a6abf5c15c424ab07cfbd5c40c06622fe648d4fe6a6b6abc224a0d0c
       name: component-sample
+      source:
+        git:
+          revision: fa8b89274a61ef0f1c257b7a84c37aa2ec844109


### PR DESCRIPTION

Signed-off-by: Hongwei Liu <hongliu@redhat.com>