### PR TITLE
fix(STONEINTG-981): fixed the apiVersion to point tekton.dev/v1

### DIFF
--- a/examples/integration_pipelinerun.yaml
+++ b/examples/integration_pipelinerun.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:

--- a/pipelines/integration_resolver_pipeline_pass_metadata.yaml
+++ b/pipelines/integration_resolver_pipeline_pass_metadata.yaml
@@ -1,5 +1,5 @@
 kind: Pipeline
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 metadata:
   name: example-pipeline
 spec:


### PR DESCRIPTION
Fixed the apiVersion to point to `tekton.dev/v1` 

more details in [STONEINTG-981](https://issues.redhat.com/browse/STONEINTG-981) 