### PR TITLE
feat(STONEINTG-946): Migrate redhat-appstudio/konflux-test

### DIFF
--- a/examples/task.yaml
+++ b/examples/task.yaml
@@ -9,7 +9,7 @@ spec:
     - name: SNAPSHOT
       description: The json string of the Snapshot under test 
   steps:
-    - image: quay.io/redhat-appstudio/konflux-test:latest
+    - image: quay.io/konflux-ci/konflux-test:latest
       env:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)

--- a/tasks/build_container.yaml
+++ b/tasks/build_container.yaml
@@ -16,7 +16,7 @@ spec:
       name: image-digest
       description: Image Digest (optional)
   steps:
-    - image: quay.io/redhat-appstudio/konflux-test:latest
+    - image: quay.io/konflux-ci/konflux-test:latest
       script: |
         echo -n "$(params.image-url)" | tee $(results.IMAGE_URL.path)
         if [ -z "$(params.image-digest)" ]; then

--- a/tasks/clone_repository.yaml
+++ b/tasks/clone_repository.yaml
@@ -16,7 +16,7 @@ spec:
       name: commit
       description: Commit SHA
   steps:
-    - image: quay.io/redhat-appstudio/konflux-test:latest
+    - image: quay.io/konflux-ci/konflux-test:latest
       script: |
         echo "$(params.url)" | tee $(results.url.path)
         if [ -z "$(params.commit)" ]; then

--- a/tasks/test_metadata.yaml
+++ b/tasks/test_metadata.yaml
@@ -29,7 +29,7 @@ spec:
       description: The JSON string of the Snapshot under test
   steps:
     - name: test-metadata
-      image: quay.io/redhat-appstudio/konflux-test:stable
+      image: quay.io/konflux-ci/konflux-test:stable
       workingDir: /workspace
       env:
         - name: SNAPSHOT

--- a/tasks/test_output.yaml
+++ b/tasks/test_output.yaml
@@ -11,7 +11,7 @@ spec:
       name: RESULT
       description: Test result to be generated
   steps:
-    - image: quay.io/redhat-appstudio/konflux-test:latest
+    - image: quay.io/konflux-ci/konflux-test:latest
       script: |
         TEST_OUTPUT=$(jq -rc --arg date $(date -u --iso-8601=seconds) --arg RESULT $(params.RESULT) --null-input \
           '{result: $RESULT, timestamp: $date, failures: 0, successes: 0, warnings: 0}')


### PR DESCRIPTION
As part of the migration effort to move all Konflux repositories to the new konflux-ci organization, we will need to move the redhat-appstudio/konflux-test repository. As part of the migration efforts all images in the integration-examples repo  need to be updated to reflect the changes.