### PR TITLE
fix(STONEINTG-998): update the pac build PLR sample with the new label

### DIFF
--- a/pipelineruns/build_pipelinerun_pac_pr_pass.yaml
+++ b/pipelineruns/build_pipelinerun_pac_pr_pass.yaml
@@ -18,6 +18,7 @@ metadata:
     pipelines.openshift.io/strategy: "s2i"
     appstudio.openshift.io/component: "component-sample"
     pipelinesascode.tekton.dev/event-type: pull_request
+    pipelinesascode.tekton.dev/pull-request: 143
     pipelinesascode.tekton.dev/state: completed
     pipelinesascode.tekton.dev/sender: Michkov
     pipelinesascode.tekton.dev/check-run-id: '7111954526'


### PR DESCRIPTION
* After we updated the definition of [this function](https://github.com/konflux-ci/integration-service/blob/64cfb95a8272cd99f69ed4028acb81887ff3cf03/tekton/build_pipeline.go#L123), integration service started checking for the presence of a new label to determine the event type of the build PLR.
* And that new label is currently absent from our build PLR sample, causing IS to incorrectly consider this build PLR related to a `push` type event.
* This commit updates our pac-based build PLR sample to contain that label so that during the local testing, the integration service considers this sample build PLR related to the `pull_request` event.