### PR TITLE
feat(STONEINTG-1099):adding task for checking components in a monorepo

### DIFF
--- a/tasks/test_component_snapshot.yaml
+++ b/tasks/test_component_snapshot.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-snapshot-component
+spec:
+  params:
+    - name: SNAPSHOT
+      description: The JSON string of the Snapshot under test
+  steps:
+    - name: test-snapshot-component
+      image: quay.io/konflux-ci/konflux-test:stable
+      workingDir: /workspace
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: SNAPSHOT_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-repo-url']
+        - name: SNAPSHOT_SHA
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sha']
+      script: |
+        #!/bin/sh
+        set -e
+        components=$(jq -c '.components[]' <<< "${SNAPSHOT}")
+        snapshotUrlUrlWithoutSuffix=$(echo $SNAPSHOT_URL | sed 's/\.git$//')
+        while read components
+        do
+          # Variables
+          componentUrl=$(echo "$components" | jq -r '.source.git.url')
+          componentUrlWithoutSuffix=$(echo $componentUrl | sed 's/\.git$//')
+          name=$(echo "$components" | jq -r '.name')
+          componentSha=$(echo "$components" | jq -r '.source.git.revision')
+            # Check if component git url equals to snapshot git url, if yes check if the snapshot SHA equals to component SHA
+            if [[ \"$componentUrlWithoutSuffix\" == $snapshotUrlUrlWithoutSuffix ]]; then
+                if [[ $componentSha != $snapshotSha ]]; then
+                echo "FAIL: Component $name has different SHA: $componentSha than the snapshot, SHA: $snapshotSha."
+                exit 1
+                fi
+            fi
+          echo "SUCCESS: Component $name matches snapshot SHA."
+        done < <(echo "$components")


### PR DESCRIPTION
This task plays role as integration test that checks if all components in a monorepo match snapshot sha from the PR.
In case that only one component SHA differs from snapshot one, test is set as FAILED. Informing about a fact that this situation occured.
Guide on how to apply this integration test is TBD.